### PR TITLE
Prepare changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,2 @@
+## Version 1.0.0
+- Initial public release

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
   },
   "devDependencies": {
-    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^3.1.0",
+    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.3.0",
     "chart.js": "^2.8.0",
     "react-chartjs-2": "^2.7.6",
     "react-rangeslider": "^2.2.0",


### PR DESCRIPTION
For [NCP-2820](https://projecttools.nordicsemi.no/jira/browse/NCP-2820): When the DTM app is publicly released, this will automatically upload the changelog, which we should maintain from then onwards.